### PR TITLE
Use minimal Tsit5-only ODE dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MatterPower"
 uuid = "743831d1-0e6a-4e86-a0c4-1a098a68aca3"
+version = "0.5.1"
 authors = ["Eiichiro Komatsu <eiichirokomatsu@me.com>"]
-version = "0.5.0"
 
 [deps]
 DoubleExponentialFormulas = "eb426421-6452-4132-80ef-4b100a757ac5"

--- a/Project.toml
+++ b/Project.toml
@@ -5,13 +5,13 @@ version = "0.5.0"
 
 [deps]
 DoubleExponentialFormulas = "eb426421-6452-4132-80ef-4b100a757ac5"
-OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 
 [compat]
 julia = "1"
 DoubleExponentialFormulas = "0.1"
-OrdinaryDiffEq = "6"
+OrdinaryDiffEqTsit5 = "1.5.0"
 Roots = "2"
 
 [extras]

--- a/src/MatterPower.jl
+++ b/src/MatterPower.jl
@@ -1,5 +1,5 @@
 module MatterPower
-using OrdinaryDiffEq
+using OrdinaryDiffEqTsit5
 using DoubleExponentialFormulas
 using Roots
 export t_nowiggle


### PR DESCRIPTION
This avoids pulling in all unused OrdinaryDiffEq solvers, instead just using the package that holds the necessary Tsit5 solver (e.g. https://docs.sciml.ai/OrdinaryDiffEq/stable/explicit/Tsit5/ and https://github.com/SciML/OrdinaryDiffEq.jl/issues/2177).

I also updated the version number to 0.5.1. If you merge, could you also tag the new release? Thanks a lot!

