### PR TITLE
Update compatibility with OrdinaryDiffEq v7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MatterPower"
 uuid = "743831d1-0e6a-4e86-a0c4-1a098a68aca3"
-version = "0.5.1"
 authors = ["Eiichiro Komatsu <eiichirokomatsu@me.com>"]
+version = "0.5.2"
 
 [deps]
 DoubleExponentialFormulas = "eb426421-6452-4132-80ef-4b100a757ac5"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 [compat]
 julia = "1"
 DoubleExponentialFormulas = "0.1"
-OrdinaryDiffEqTsit5 = "1.5.0"
+OrdinaryDiffEqTsit5 = "1.5.0, 2"
 Roots = "2"
 
 [extras]


### PR DESCRIPTION
Just a quick fix to make the package compatible with the [just released OrdinaryDiffEq v7](https://github.com/SciML/OrdinaryDiffEq.jl/blob/master/NEWS.md) (i.e. OrdinaryDiffEqTsit5 v2).

For this package I do not think there is any breaking change, the ODE problem/solution in the README works as before:
```julia
using MatterPower
using Roots

redshift = 0

As, ns, kpivot = 2.097e-9, 0.9652, 0.05
Ωm, ΩΛ, Ωb = 0.315, 0.685, 0.049
Ωk = 1 - Ωm - ΩΛ
h0 = 0.674
ωm, fb = Ωm * h0^2, Ωb / Ωm

sol = setup_growth(Ωm, ΩΛ)
```
```
retcode: Success
Interpolation: specialized 4th order "free" interpolation
t: 14-element Vector{Float64}:
 0.01
 0.022953867736178503
 0.031531905187150565
 0.049203214815302806
 0.06926271298898215
 0.10020497525710349
 0.14112458313909726
 0.19963838943517664
 0.2797076745273747
 0.39005457654466275
 0.5369751072128826
 0.7308944397043325
 0.9959456332800616
 1.0
u: 14-element Vector{Vector{Float64}}:
 [0.01, -0.05612492182622617]
 [0.02295541884152758, -0.08503655077820088]
 [0.03153369850321245, -0.09966686924337718]
 [0.049204280831942296, -0.12449593801942577]
 [0.06925835334116488, -0.14769401998314607]
 [0.10017201393841266, -0.17758800034724898]
 [0.14097787332972836, -0.21056410694631025]
 [0.19902909149672027, -0.24981018198988802]
 [0.27735937391633086, -0.2937117124753853]
 [0.38144459980373174, -0.3408639039409869]
 [0.5084775973259668, -0.384105391739714]
 [0.6483259792730928, -0.4127179339474922]
 [0.7861779174068327, -0.41545930944542664]
 [0.7878672231233184, -0.4152872556237772]
```
and
```julia
a = 1 / (1 + redshift)
D1 = sol(a)[1]
```
```
0.7878672231233184
```